### PR TITLE
use "context" package instead of "golang.go/x/net/context"

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,10 +1,10 @@
 package otgrpc
 
 import (
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"io"

--- a/server.go
+++ b/server.go
@@ -1,10 +1,10 @@
 package otgrpc
 
 import (
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/test/interceptor_test.go
+++ b/test/interceptor_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/opentracing-contrib/go-grpc"
+	"context"
 	testpb "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/test/otgrpc_testing"
+	"github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go/mocktracer"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/test/otgrpc_testing/test.pb.go
+++ b/test/otgrpc_testing/test.pb.go
@@ -19,7 +19,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Context is available in the stdlib since Golang 1.7.
Replace "golang.go/x/net/context" imports with "context".

This reduces the external dependencies of the package and ensure the
context package with the latest improvements and fixes from the stdlib
is used.