### PR TITLE
Report context cancelation as non-error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package otgrpc
 
 import (
+	"context"
+	"errors"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"google.golang.org/grpc/codes"
@@ -57,6 +60,9 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	code := codes.Unknown
 	if s, ok := status.FromError(err); ok {
 		code = s.Code()
+	} else if errors.Is(err, context.Canceled) {
+		code = codes.Canceled
+		err = nil // Someone else canceled this operation - we should not flag it as an error.
 	}
 	span.SetTag("response_code", code)
 	span.SetTag("response_class", c)


### PR DESCRIPTION
Someone else canceled this operation; we should not flag it as an error.

Example of a span flagged as an error when the operation was cancelled as un-needed:
![image](https://user-images.githubusercontent.com/8125524/134396999-d278891a-9564-4c30-a1a8-a8576f1a4baa.png)

This is a little bit similar to #1, but for the case that the Go context was canceled, rather than the gRPC operation.