### PR TITLE
Wrap errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
-    # - wrapcheck
+    - wrapcheck
   settings:
     govet:
       enable-all: true

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package otgrpc
 
 import (
 	"context"
+	"fmt"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -138,5 +139,9 @@ func extractSpanContext(ctx context.Context, tracer opentracing.Tracer) (opentra
 	if !ok {
 		md = metadata.New(nil)
 	}
-	return tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
+	spanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract span context: %w", err)
+	}
+	return spanContext, nil
 }


### PR DESCRIPTION
This pull request includes several improvements to error handling and linter configurations in the `otgrpc` package. The most important changes include enabling the `wrapcheck` linter, adding error wrapping for better context in error messages, and updating the `client.go` and `server.go` files to use formatted error messages.

### Error Handling Improvements:

* [`client.go`](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR197-R232): Added error wrapping to provide more context in error messages for functions `Header`, `SendMsg`, `RecvMsg`, and `CloseSend`. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR197-R232) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR197-R232) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR197-R232) [[4]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR197-R232)
* [`server.go`](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L141-R146): Added error wrapping in the `extractSpanContext` function to provide more context when extracting span context fails.

### Linter Configuration:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L49-R49): Enabled the `wrapcheck` linter to ensure that errors are properly wrapped with context.

### Additional Imports:

* `client.go` and `server.go`: Added the `fmt` package import to support formatted error messages. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR6) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R5)